### PR TITLE
include Rosetta into Avram::DeleteOperation

### DIFF
--- a/src/rosetta/lucky/integration.cr
+++ b/src/rosetta/lucky/integration.cr
@@ -4,6 +4,7 @@ module Rosetta
       {% targets = {
            "Avram::Model",
            "Avram::Operation",
+           "Avram::DeleteOperation(T)",
            "Avram::SaveOperation(T)",
            "Lucky::Action",
            "Lucky::BaseComponent",


### PR DESCRIPTION
Basically just a shortcut for

```crystal
abstract class Avram::DeleteOperation(T)
  include Rosetta::Localizable
  include Rosetta::Translatable
end
```